### PR TITLE
[NOT FOR MERGE] make this compile on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,9 @@ add_subdirectory(Graphics)
 add_subdirectory(Main)
 
 # Linux Test Project
-if(UNIX)
-	add_subdirectory(Test)
-endif(UNIX)
+#if(UNIX)
+#	add_subdirectory(Test)
+#endif(UNIX)
 
 # Enabled project filters on windows
 if(MSVC)

--- a/Graphics/include/Graphics/Font.hpp
+++ b/Graphics/include/Graphics/Font.hpp
@@ -34,8 +34,8 @@ namespace Graphics
 		virtual Ref<TextRes> CreateText(const WString& str, uint32 nFontSize) = 0;
 	};
 
-	typedef Ref<FontRes> Font;
+    typedef Ref<FontRes> GlFont;
 	typedef Ref<TextRes> Text;
 
-	DEFINE_RESOURCE_TYPE(Font, FontRes);
+    DEFINE_RESOURCE_TYPE(GlFont, FontRes);
 }

--- a/Graphics/include/Graphics/Keys.hpp
+++ b/Graphics/include/Graphics/Keys.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+// X11/X.h defines this
+#ifdef None
+#undef None
+#endif
+
 namespace Graphics
 {
 	enum class Key : uint8

--- a/Graphics/include/Graphics/OpenGL.hpp
+++ b/Graphics/include/Graphics/OpenGL.hpp
@@ -22,7 +22,7 @@ namespace Graphics
 #else
 		GLXContext m_renderContext = 0;
 #endif
-		Window* m_window;
+        DesktopWindow* m_window;
 		class FramebufferRes* m_boundFramebuffer;
 
 		friend class ShaderRes;
@@ -35,7 +35,7 @@ namespace Graphics
 		OpenGL();
 		~OpenGL();
 		void InitResourceManagers();
-		bool Init(Window& window);
+        bool Init(DesktopWindow& window);
 		void UnbindFramebuffer();
 
 		Recti GetViewport() const;

--- a/Graphics/include/Graphics/ResourceTypes.hpp
+++ b/Graphics/include/Graphics/ResourceTypes.hpp
@@ -16,7 +16,7 @@ template<> struct ResourceManagerTypes<ResourceType::_EnumMember>\
 		SpriteMap,
 		Texture,
 		Framebuffer,
-		Font,
+		GlFont,
 		Mesh,
 		Shader,
 		Material,

--- a/Graphics/include/Graphics/Window.hpp
+++ b/Graphics/include/Graphics/Window.hpp
@@ -14,11 +14,11 @@ namespace Graphics
 		Simple window class that manages window messages, window style and input
 		Renamed from Window to DesktopWindow to avoid conflicts with libX11 on Linux
 	*/
-	class Window : Unique
+    class DesktopWindow : Unique
 	{
 	public:
-		Window(Vector2i size = Vector2i(800, 600), const CustomWindowStyle& customStyle = CustomWindowStyle::Default);
-		~Window();
+        DesktopWindow(Vector2i size = Vector2i(800, 600), const CustomWindowStyle& customStyle = CustomWindowStyle::Default);
+        ~DesktopWindow();
 		// Show the window
 		void Show();
 		// Hide the window

--- a/Graphics/src/Font.cpp
+++ b/Graphics/src/Font.cpp
@@ -325,17 +325,17 @@ namespace Graphics
 		}
 	};
 
-	Font FontRes::Create(OpenGL* gl, const String& assetPath)
+    GlFont FontRes::Create(OpenGL* gl, const String& assetPath)
 	{
 		Font_Impl* pImpl = new Font_Impl(gl);
 		if(pImpl->Init(assetPath))
 		{
-			return GetResourceManager<ResourceType::Font>().Register(pImpl);
+            return GetResourceManager<ResourceType::GlFont>().Register(pImpl);
 		}
 		else
 		{
 			delete pImpl;
-			return Font();
+            return GlFont();
 		}
 	}
 

--- a/Graphics/src/Linux/Window.cpp
+++ b/Graphics/src/Linux/Window.cpp
@@ -9,9 +9,9 @@ namespace Graphics
 	{
 	public:
 		// Handle to outer class to send delegates
-		Window& outer;
+        DesktopWindow& outer;
 	public:
-		Window_Impl(Window& outer, Vector2i size, const CustomWindowStyle& customStyle) : outer(outer)
+        Window_Impl(DesktopWindow& outer, Vector2i size, const CustomWindowStyle& customStyle) : outer(outer)
 		{
 			// Initialize button mapping
 			m_keyMapping.AddRangeMapping(XK_A, XK_Z, Key::A);
@@ -118,69 +118,71 @@ namespace Graphics
 		}
 
 		Atom m_delWindow;
-		
+
+		KeyMap m_keyMapping;
+
 		bool m_closed = false;
 		Vector2i m_size;
-		::Window m_window;
+        ::Window m_window;
 		Display* m_display;
 		int m_screen;
 		int m_evMask;
 		WString m_caption;
 	};
 
-	Window::Window(Vector2i size, const CustomWindowStyle& customStyle)
+    DesktopWindow::DesktopWindow(Vector2i size, const CustomWindowStyle& customStyle)
 	{
 		m_impl = new Window_Impl(*this, size, customStyle);
 	}
-	Window::~Window()
+	DesktopWindow::~DesktopWindow()
 	{
 		delete m_impl;
 	}
-	void Window::Show()
+	void DesktopWindow::Show()
 	{
 		m_impl->Show();
 	}
-	void Window::Hide()
+	void DesktopWindow::Hide()
 	{
 		m_impl->Hide();
 	}
-	bool Window::Update()
+	bool DesktopWindow::Update()
 	{
 		return m_impl->Update();
 	}
-	void* Window::Handle()
+	void* DesktopWindow::Handle()
 	{
 		return (void*)m_impl->m_window;
 	}
-	void Window::SetCaption(const WString& cap)
+	void DesktopWindow::SetCaption(const WString& cap)
 	{
 		m_impl->SetCaption(cap);
 	}
-	void Window::Close()
+	void DesktopWindow::Close()
 	{
 		m_impl->m_closed = true;
 	}
-	void Window::SetWindowStyle(WindowStyle style)
+	void DesktopWindow::SetWindowStyle(WindowStyle style)
 	{
 	}
-	Vector2i Window::GetWindowSize()
+	Vector2i DesktopWindow::GetWindowSize()
 	{
 		return m_impl->GetWindowSize();
 	}
-	void Window::SetWindowSize(const Vector2i& size)
+	void DesktopWindow::SetWindowSize(const Vector2i& size)
 	{
 		m_impl->SetWindowSize(size);
 	}
-	void Window::SwitchFullscreen(uint32 monitorID)
+	void DesktopWindow::SwitchFullscreen(uint32 monitorID)
 	{
 	}
-	void Window::SetStyles(uint32 mask)
+	void DesktopWindow::SetStyles(uint32 mask)
 	{
 	}
-	void Window::UnsetStyles(uint32 mask)
+	void DesktopWindow::UnsetStyles(uint32 mask)
 	{
 	}
-	uint32 Window::HasStyle(uint32 mask)
+	uint32 DesktopWindow::HasStyle(uint32 mask)
 	{
 		return 0;
 	}

--- a/Graphics/src/Windows/OpenGL.cpp
+++ b/Graphics/src/Windows/OpenGL.cpp
@@ -25,7 +25,7 @@ namespace Graphics
 			ResourceManagers::DestroyResourceManager<ResourceType::Mesh>();
 			ResourceManagers::DestroyResourceManager<ResourceType::Texture>();
 			ResourceManagers::DestroyResourceManager<ResourceType::Shader>();
-			ResourceManagers::DestroyResourceManager<ResourceType::Font>();
+            ResourceManagers::DestroyResourceManager<ResourceType::GlFont>();
 			ResourceManagers::DestroyResourceManager<ResourceType::Material>();
 			ResourceManagers::DestroyResourceManager<ResourceType::Framebuffer>();
 			ResourceManagers::DestroyResourceManager<ResourceType::ParticleSystem>();
@@ -46,7 +46,7 @@ namespace Graphics
 		ResourceManagers::CreateResourceManager<ResourceType::Mesh>();
 		ResourceManagers::CreateResourceManager<ResourceType::Texture>();
 		ResourceManagers::CreateResourceManager<ResourceType::Shader>();
-		ResourceManagers::CreateResourceManager<ResourceType::Font>();
+        ResourceManagers::CreateResourceManager<ResourceType::GlFont>();
 		ResourceManagers::CreateResourceManager<ResourceType::Material>();
 		ResourceManagers::CreateResourceManager<ResourceType::Framebuffer>();
 		ResourceManagers::CreateResourceManager<ResourceType::ParticleSystem>();

--- a/Graphics/src/Windows/Window.cpp
+++ b/Graphics/src/Windows/Window.cpp
@@ -22,9 +22,9 @@ namespace Graphics
 	{
 	public:
 		// Handle to outer class to send delegates
-		Window& outer;
+        DesktopWindow& outer;
 	public:
-		Window_Impl(Window& outer, Vector2i size, const CustomWindowStyle& customStyle) : outer(outer)
+        Window_Impl(DesktopWindow& outer, Vector2i size, const CustomWindowStyle& customStyle) : outer(outer)
 		{
 			// Initialize button mapping
 			m_keyMapping.AddRangeMapping('A', 'Z', Key::A);
@@ -491,39 +491,39 @@ namespace Graphics
 		return DefWindowProc(wnd, msg, wp, lp);
 	}
 
-	Window::Window(Vector2i size, const CustomWindowStyle& customStyle)
+	DesktopWindow::DesktopWindow(Vector2i size, const CustomWindowStyle& customStyle)
 	{
 		m_impl = new Window_Impl(*this, size, customStyle);
 	}
-	Window::~Window()
+	DesktopWindow::~DesktopWindow()
 	{
 		delete m_impl;
 	}
-	void Window::Show()
+	void DesktopWindow::Show()
 	{
 		m_impl->Show();
 	}
-	void Window::Hide()
+	void DesktopWindow::Hide()
 	{
 		m_impl->Hide();
 	}
-	bool Window::Update()
+	bool DesktopWindow::Update()
 	{
 		return m_impl->Update();
 	}
-	void* Window::Handle()
+	void* DesktopWindow::Handle()
 	{
 		return (void*)m_impl->m_handle;
 	}
-	void Window::SetCaption(const WString& cap)
+	void DesktopWindow::SetCaption(const WString& cap)
 	{
 		m_impl->SetCaption(cap);
 	}
-	void Window::Close()
+	void DesktopWindow::Close()
 	{
 		m_impl->m_closed = true;
 	}
-	void Window::SetWindowStyle(WindowStyle style)
+	void DesktopWindow::SetWindowStyle(WindowStyle style)
 	{
 		if(style == WindowStyle::Windowed)
 		{
@@ -534,11 +534,11 @@ namespace Graphics
 			UnsetStyles(WS_OVERLAPPEDWINDOW);
 		}
 	}
-	Vector2i Window::GetWindowSize()
+	Vector2i DesktopWindow::GetWindowSize()
 	{
 		return m_impl->GetWindowSize();
 	}
-	void Window::SetWindowSize(const Vector2i& size)
+	void DesktopWindow::SetWindowSize(const Vector2i& size)
 	{
 		m_impl->SetWindowSize(size);
 	}
@@ -548,7 +548,7 @@ namespace Graphics
 		out.Add(*lprcMonitor);
 		return true;
 	}
-	void Window::SwitchFullscreen(uint32 monitorID)
+	void DesktopWindow::SwitchFullscreen(uint32 monitorID)
 	{
 		if(!m_impl->m_fullscreen)
 		{
@@ -599,25 +599,25 @@ namespace Graphics
 			m_impl->m_fullscreen = false;
 		}
 	}
-	void Window::SetStyles(uint32 mask)
+	void DesktopWindow::SetStyles(uint32 mask)
 	{
 		LONG style = GetWindowLong(m_impl->m_handle, GWL_STYLE);
 		style |= mask;
 		SetWindowLong(m_impl->m_handle, GWL_STYLE, style);
 	}
-	void Window::UnsetStyles(uint32 mask)
+	void DesktopWindow::UnsetStyles(uint32 mask)
 	{
 		LONG style = GetWindowLong(m_impl->m_handle, GWL_STYLE);
 		mask = ~mask;
 		style &= mask; // Apply mask to disable only given styles
 		SetWindowLong(m_impl->m_handle, GWL_STYLE, style);
 	}
-	uint32 Window::HasStyle(uint32 mask)
+	uint32 DesktopWindow::HasStyle(uint32 mask)
 	{
 		LONG style = GetWindowLong(m_impl->m_handle, GWL_STYLE);
 		return style & mask;
 	}
-	void Window::IsKeyPressed(Key key) const
+	void DesktopWindow::IsKeyPressed(Key key) const
 	{
 
 	}

--- a/Main/Application.cpp
+++ b/Main/Application.cpp
@@ -9,7 +9,7 @@
 #include "Profiling.hpp"
 
 OpenGL* g_gl = nullptr;
-Window* g_gameWindow = nullptr;
+DesktopWindow* g_gameWindow = nullptr;
 Application* g_application = nullptr;
 
 Game* g_game = nullptr;
@@ -39,9 +39,13 @@ int32 Application::Run()
 		ProfilerScope $("Application Setup");
 
 		// Split up command line parameters
+#ifdef _WIN32
 		String cmdLine = Utility::ConvertToANSI(GetCommandLine());
 		m_commandLine = Path::SplitCommandLine(cmdLine);
 		assert(m_commandLine.size() >= 1);
+#else
+        // TODO: Linux
+#endif
 
 		m_allowMapConversion = false;
 		bool debugMute = false;
@@ -76,7 +80,7 @@ int32 Application::Run()
 
 		// Create the game window
 		g_resolution = Vector2i{ (int32)(g_screenHeight * g_aspectRatio), (int32)g_screenHeight };
-		g_gameWindow = new Window(g_resolution);
+        g_gameWindow = new DesktopWindow(g_resolution);
 		g_gameWindow->Show();
 		m_OnWindowResized(g_resolution);
 		g_gameWindow->OnKeyPressed.Add(this, &Application::m_OnKeyPressed);

--- a/Main/Application.hpp
+++ b/Main/Application.hpp
@@ -2,7 +2,7 @@
 #include "Sample.hpp"
 
 extern class OpenGL* g_gl;
-extern class Window* g_gameWindow;
+extern class DesktopWindow* g_gameWindow;
 extern float g_aspectRatio;
 extern Vector2i g_resolution;
 extern class Application* g_application;

--- a/Main/Audio/Audio.cpp
+++ b/Main/Audio/Audio.cpp
@@ -4,6 +4,7 @@
 #include "AudioStream.hpp"
 #include "Audio_Impl.hpp"
 #include "DSP.hpp"
+#include <unistd.h>
 
 Audio* g_audio = nullptr;
 Audio_Impl impl;
@@ -81,7 +82,11 @@ void Audio_Impl::AudioThread()
 
 			delete[] tempData;
 		}
+#ifdef _WIN32
 		Sleep(sleepDuration);
+#else
+		sleep(sleepDuration);
+#endif
 	}
 }
 void Audio_Impl::Start()
@@ -145,7 +150,7 @@ Audio::~Audio()
 	assert(g_audio == this);
 	g_audio = nullptr;
 }
-bool Audio::Init(class Window& window)
+bool Audio::Init(class DesktopWindow& window)
 {
 	m_window = &window;
 	audioLatency = 0;

--- a/Main/Audio/Audio.hpp
+++ b/Main/Audio/Audio.hpp
@@ -14,7 +14,7 @@ class Audio : Unique
 public:
 	Audio();
 	~Audio();
-	bool Init(class Window& window);
+    bool Init(class DesktopWindow& window);
 	void SetGlobalVolume(float vol);
 
 	// Opens a stream at path
@@ -32,6 +32,6 @@ public:
 	int64 audioLatency;
 
 private:
-	class Window* m_window;
+    class DesktopWindow* m_window;
 	bool m_initialized = false;
 };

--- a/Main/Audio/AudioOutput.cpp
+++ b/Main/Audio/AudioOutput.cpp
@@ -1,8 +1,10 @@
 #include "stdafx.h"
+#ifdef _WIN32
 #include "Audioclient.h"
 #include "Mmdeviceapi.h"
 #include "comdef.h"
 #include "Functiondiscoverykeys_devpkey.h"
+#endif
 #include "AudioOutput.hpp"
 
 #define REFTIME_NS (100)
@@ -13,11 +15,13 @@
               if ((punk) != NULL)  \
                 { (punk)->Release(); (punk) = nullptr; }
 
+#ifdef _WIN32
 static uint32_t freq = 44100;
 static uint32_t channels = 2;
 static uint32_t numBuffers = 2;
 static uint32_t bufferLength = 10;
 static REFERENCE_TIME bufferDuration = (REFERENCE_TIME)(bufferLength * REFTIMES_PER_MILLISEC);
+#endif
 
 AudioOutput::AudioOutput()
 {
@@ -25,6 +29,7 @@ AudioOutput::AudioOutput()
 
 bool AudioOutput::Init()
 {
+#ifdef _WIN32
 	// Initialize the WASAPI device enumerator
 	HRESULT res;
 	const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
@@ -98,18 +103,22 @@ bool AudioOutput::Init()
 
 	res = m_audioClient->Start();
 	return true;
+#endif
 }
 AudioOutput::~AudioOutput()
 {
+#ifdef _WIN32
 	HRESULT res = m_audioClient->Stop();
 
 	CoTaskMemFree(m_format);
 	SAFE_RELEASE(m_device);
 	SAFE_RELEASE(m_audioClient);
 	SAFE_RELEASE(m_audioRenderClient);
+#endif
 }
 bool AudioOutput::Begin(float*& buffer, uint32_t& numSamples)
 {
+#ifdef _WIN32
 	// See how much buffer space is available.
 	uint32_t numFramesPadding;
 	m_audioClient->GetCurrentPadding(&numFramesPadding);
@@ -122,23 +131,32 @@ bool AudioOutput::Begin(float*& buffer, uint32_t& numSamples)
 		return true;
 	}
 	return false;
+#endif
 }
 void AudioOutput::End(uint32_t numSamples)
 {
+#ifdef _WIN32
 	if(numSamples > 0)
 	{
 		m_audioRenderClient->ReleaseBuffer(numSamples, 0);
 	}
+#endif
 }
 uint32_t AudioOutput::GetNumChannels() const
 {
+#ifdef _WIN32
 	return m_format->nChannels;
+#endif
 }
 uint32_t AudioOutput::GetSampleRate() const
 {
+#ifdef _WIN32
 	return m_format->nSamplesPerSec;
+#endif
 }
 double AudioOutput::GetBufferLength() const
 {
+#ifdef _WIN32
 	return m_bufferLength;
+#endif
 }

--- a/Main/Game.cpp
+++ b/Main/Game.cpp
@@ -327,7 +327,7 @@ public:
 	}
 
 	// Draws HUD and debug overlay text
-	Font font;
+	GlFont font;
 	Material fontMaterial;
 	Mesh guiQuad;
 	Material guiTextureMaterial;

--- a/Main/KShootMap.hpp
+++ b/Main/KShootMap.hpp
@@ -69,9 +69,9 @@ public:
 	Vector<KShootBlock> blocks;
 
 private:
-	static const uint32_t KShootMap::c_laserStart;
-	static const uint32_t KShootMap::c_laserEnd;
-	static const uint32_t KShootMap::c_laserRange;
+	static const uint32_t c_laserStart;
+	static const uint32_t c_laserEnd;
+	static const uint32_t c_laserRange;
 	static const char* c_sep;
 
 };

--- a/Main/Main.cpp
+++ b/Main/Main.cpp
@@ -1,7 +1,11 @@
 #include "stdafx.h"
 #include "Application.hpp"
 
+#ifdef _WIN32
 int32 __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
+#else
+int main(int argc, char **argv)
+#endif
 {
 	new Application();
 	int32 ret = g_application->Run();

--- a/Main/Scoring.cpp
+++ b/Main/Scoring.cpp
@@ -2,6 +2,7 @@
 #include "Scoring.hpp"
 #include "BeatmapPlayback.hpp"
 #include <math.h>
+#include <limits.h>
 
 const float Scoring::idleLaserMoveSpeed = 1.0f;
 const MapTime Scoring::maxEarlyHitTime = 80;

--- a/Main/stdafx.h
+++ b/Main/stdafx.h
@@ -4,14 +4,16 @@
 // OpenGL headers
 #include <Graphics/GL.hpp>
 
-// Windows Header Files:
+#ifdef _WIN32
+// Windows Header Files
 #include <windows.h>
+#include <tchar.h>
+#endif
 
 // C RunTime Header Files
 #include <stdlib.h>
 #include <malloc.h>
 #include <memory.h>
-#include <tchar.h>
 #include <cinttypes>
 
 // TODO: reference additional headers your program requires here

--- a/Shared/include/Shared/Rect.hpp
+++ b/Shared/include/Shared/Rect.hpp
@@ -87,6 +87,7 @@ template<typename T>
 class RectangleBase3D : public RectangleBase<T>
 {
 public:
+	typedef VectorMath::VectorBase<T, 2> VectorType;
 	using RectangleBase<T>::RectangleBase;
 	using RectangleBase<T>::RectangleBase::pos;
 	using RectangleBase<T>::RectangleBase::size;

--- a/Shared/include/Shared/String.hpp
+++ b/Shared/include/Shared/String.hpp
@@ -121,7 +121,7 @@ const T* StringBase<T>::operator*() const
 template<typename T>
 bool StringBase<T>::Split(const StringBase& delim, StringBase* l, StringBase* r) const
 {
-	size_t f = find(delim);
+	size_t f = this->find(delim);
 	if(f == -1)
 		return false;
 	StringBase selfCopy = *this;

--- a/Shared/include/Shared/Vector.hpp
+++ b/Shared/include/Shared/Vector.hpp
@@ -109,7 +109,7 @@ public:
 	}
 
 	template<typename Predicate>
-	void Sort(Predicate& pred)
+	void Sort(const Predicate& pred)
 	{
 		std::sort(begin(), end(), pred);
 	}


### PR DESCRIPTION
**Not for merge**
---

This patch should give you some ideas of the futher work on the Linux version.

 - Compiles using GCC and Clang, some adjustments has been done.
 - Game don't work on Linux, just compiles!  Side Note: On the **master** branch of my fork I was able to run the game and I got a error message about unable to load the embeded default font.

```Font``` has been renamed to ```GlFont``` (better name?) because it conflicts with X11's Font typedef.
```Window``` has been renamed to ```DesktopWindow``` because it conflicts with X11's Window typedef.

Even more changes are done on the **master** ( GhettoGirl/unnamed-sdvx-clone@06d4dd7 ) branch. You should also take a look at the commit there.

--

About the **Sort** template function in ``` Shared/include/Shared/Vector.hpp```. You cannot pass a lambda function without being a object (std::function) when the argument takes a reference. There are a quite a lot of compile errors because of this.
Why the hell does this even compile in MSVC????????? :confused: 

Option A: Change it to a constant reference as I did.
Option B: Add a overload which takes a constant reference.
Option C: Store all lambda functions which are used for sorting into a std::function.

--

In ```Graphics/include/Graphics/Keys.hpp```: ```None``` is defined in the X11 headers, since it is just a macro it can be safely undefined.

--

In ```Graphics/src/Linux/Window.cpp``` there is a missing ```KeyMap``` member variable.

--

In ```Main/KShootMap.hpp```

```diff
-	static const uint32_t KShootMap::c_laserStart;
-	static const uint32_t KShootMap::c_laserEnd;
-	static const uint32_t KShootMap::c_laserRange;
+	static const uint32_t c_laserStart;
+	static const uint32_t c_laserEnd;
+	static const uint32_t c_laserRange;
```

I don't know what this is supposed to be, but in GCC and Clang this doesn't work! MSVC sure is a strange compiler :confused:

--

I guess ```GetCommandLine()``` is a Windows specific thing?

--

In ```Main/stdafx.h```: ```<tchar.h>``` is a Windows-**only** header, it needs to be moved in the ```#ifdef _WIN32``` block.

--

**Make sure to checkout the comments in the diff too** :wink:
