### PR TITLE
Logger: use better colors on Linux

### DIFF
--- a/Shared/src/Log.cpp
+++ b/Shared/src/Log.cpp
@@ -2,6 +2,7 @@
 #include "Log.hpp"
 #include "Path.hpp"
 #include <ctime>
+#include <map>
 
 class Logger_Impl
 {
@@ -60,6 +61,10 @@ Logger::Logger()
 }
 Logger::~Logger()
 {
+#ifndef _WIN32
+	// Reset terminal colors
+	printf("\x1b[39m\x1b[0m");
+#endif
 	delete m_impl;
 }
 Logger& Logger::Get()
@@ -72,7 +77,7 @@ void Logger::SetColor(Color color)
 #ifdef _WIN32
 	if(m_impl->consoleHandle)
 	{
-		uint8 params[] = 
+		static uint8 params[] =
 		{
 			FOREGROUND_INTENSITY | FOREGROUND_RED,
 			FOREGROUND_INTENSITY | FOREGROUND_GREEN,
@@ -86,16 +91,19 @@ void Logger::SetColor(Color color)
 		SetConsoleTextAttribute(m_impl->consoleHandle, params[(size_t)color]);
 	}
 #else
-	int params[] = 
-	{
-		31,32,34,
-		33,36,35,
-		37,37
+	static std::map<Color, const char*> params = {
+		{Color::Red,     "200;0;0"},
+		{Color::Green,   "0;200;0"},
+		{Color::Blue,    "0;70;200"},
+		{Color::Yellow,  "200;180;0"},
+		{Color::Cyan,    "0;200;200"},
+		{Color::Magenta, "200;0;200"},
+		{Color::Gray,    "140;140;140"}
 	};
-	if(color == Color::Gray)
-		printf("\x1b[2;%dm", params[(size_t)color]); // Dim
+	if(color == Color::White)
+		printf("\x1b[39m");
 	else
-		printf("\x1b[1;%dm", params[(size_t)color]); // Bright
+		printf("\x1b[38;2;%sm", params[color]);
 #endif
 }
 void Logger::Log(const String& msg, Logger::Severity severity)


### PR DESCRIPTION
Terminal backgrounds may not be always black, there are people which prefer bright/white terminal backgrounds. Yellow and White obiously aren't readable on such a background color.

The colors which are now used are universal to bright and dark backgrounds and readable. For this the terminal emulator needs to support 16-million (24-bit) colors. If that mode is not supported, the underlaying shell fallbacks to the default 8/16 colors by default.

As an extend the color is also reset to default on application cleanup to prevent the last used color to affect the users shell.

Here is a screenshot to see the changes in action :smiley: 
![screenshot_20160822_083708](https://cloud.githubusercontent.com/assets/13280758/17845851/31b158de-6845-11e6-9636-acfb253c3e52.png)

--

If you have a better idea how to solve this problem, let me know.